### PR TITLE
Revert "chore(deps): update container image docker.io/calico/pod2daemon-flexvol to v3.24.1"

### DIFF
--- a/cluster/core/calico.yaml
+++ b/cluster/core/calico.yaml
@@ -4578,7 +4578,7 @@ spec:
         # Adds a Flex Volume Driver that creates a per-pod Unix Domain Socket to allow Dikastes
         # to communicate with Felix over the Policy Sync API.
         - name: flexvol-driver
-          image: docker.io/calico/pod2daemon-flexvol:v3.24.1
+          image: docker.io/calico/pod2daemon-flexvol:v3.23.1
           volumeMounts:
             - name: flexvol-driver-host
               mountPath: /host/driver


### PR DESCRIPTION
Reverts ergho/homelab-ops#170