### PR TITLE
Revert "chore(deps): update container image docker.io/calico/node to v3.24.1"

### DIFF
--- a/cluster/core/calico.yaml
+++ b/cluster/core/calico.yaml
@@ -4589,7 +4589,7 @@ spec:
         # container programs network policy and routes on each
         # host.
         - name: calico-node
-          image: docker.io/calico/node:v3.24.1
+          image: docker.io/calico/node:v3.23.1
           envFrom:
             - configMapRef:
                 # Allow KUBERNETES_SERVICE_HOST and KUBERNETES_SERVICE_PORT to be overridden for eBPF mode.


### PR DESCRIPTION
Reverts ergho/homelab-ops#169