### PR TITLE
Revert "chore(deps): update container image docker.io/calico/kube-controllers to v3.24.1"

### DIFF
--- a/cluster/core/calico.yaml
+++ b/cluster/core/calico.yaml
@@ -4807,7 +4807,7 @@ spec:
       priorityClassName: system-cluster-critical
       containers:
         - name: calico-kube-controllers
-          image: docker.io/calico/kube-controllers:v3.24.1
+          image: docker.io/calico/kube-controllers:v3.23.1
           env:
             # Choose which controllers to run.
             - name: ENABLED_CONTROLLERS


### PR DESCRIPTION
Reverts ergho/homelab-ops#168